### PR TITLE
fix for multivalue fields within repeatable groups

### DIFF
--- a/src/Meta_Split.php
+++ b/src/Meta_Split.php
@@ -100,7 +100,7 @@ class CMB2_Meta_Split {
 		$sub_key = is_numeric( $sub_key ) ? '' : $sub_key;
 
 		foreach ( $v as $key => $entry ) {
-			if ( is_array( $entry ) ) {
+			if ( is_array( $entry ) && is_numeric( $key ) ) {
 				$this->update_sub_meta( $args, $id, $entry, $key );
 			} else {
 				$postfix      = is_numeric( $key ) ? '' : $sub_key . '_' . $key;


### PR DESCRIPTION
PROBLEM: if a field that can contain multiple values, like multicheck or another repeatable field is nested within a repeatable group, multiple copies of the serialized data are stored in the database each time a post is updated.

This fixes that issue but also prevents this data from being split out into it's own postmeta entry